### PR TITLE
Replaced prepublish with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/react-dailymotion.js",
   "module": "dist/react-dailymotion.mjs",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "ROLLUP=1 rollup -c",
     "lint": "eslint --cache .",
     "test": "npm run lint && TESTS=1 mocha",


### PR DESCRIPTION
```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```