### PR TITLE
Uses env global for eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  env: {
+    "browser": true
+  },
   extends: 'airbnb',
   rules: {
     // I disagree

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    "browser": true
+    browser: true,
   },
   extends: 'airbnb',
   rules: {

--- a/example/app.js
+++ b/example/app.js
@@ -1,4 +1,3 @@
-/* global document */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Dailymotion from '..';

--- a/src/loadSdk.js
+++ b/src/loadSdk.js
@@ -1,4 +1,3 @@
-/* global window */
 import loadScript from 'load-script2';
 
 let sdk = false;


### PR DESCRIPTION
https://eslint.org/docs/user-guide/configuring
> browser - browser global variables.

Variables like `window` and `document` are should be enabled by setting `env: {global: true}` 
